### PR TITLE
Feature/json log improvements

### DIFF
--- a/src/main/java/com/github/onsdigital/logging/layouts/model/JsonLogItem.java
+++ b/src/main/java/com/github/onsdigital/logging/layouts/model/JsonLogItem.java
@@ -2,6 +2,8 @@ package com.github.onsdigital.logging.layouts.model;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.github.onsdigital.logging.builder.LogParameters;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.slf4j.MDC;
@@ -18,15 +20,27 @@ import static com.github.onsdigital.logging.util.RequestLogUtil.REQUEST_ID_KEY;
  * POJO representing a json log item.
  */
 @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+@JsonPropertyOrder({ "time", "level", "name", "thread", "request", "host" })
 public class JsonLogItem {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
+    @JsonProperty("time")
     protected String timestamp;
+
+    @JsonProperty("level")
     protected String level;
+
+    @JsonProperty("name")
     protected String loggerName;
+
+    @JsonProperty("thread")
     protected String threadName;
+
+    @JsonProperty("request")
     protected String requestId;
+
+    @JsonProperty("host")
     protected String remoteHost;
     protected String description;
     protected Map<String, Object> parameters;

--- a/src/main/java/com/github/onsdigital/logging/layouts/model/JsonLogItem.java
+++ b/src/main/java/com/github/onsdigital/logging/layouts/model/JsonLogItem.java
@@ -3,6 +3,7 @@ package com.github.onsdigital.logging.layouts.model;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.github.onsdigital.logging.builder.LogParameters;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.slf4j.MDC;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ import static com.github.onsdigital.logging.util.RequestLogUtil.REQUEST_ID_KEY;
 /**
  * POJO representing a json log item.
  */
+@JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
 public class JsonLogItem {
 
     protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");


### PR DESCRIPTION
Added annotations to the json log object to tailor the json output.

- Do not output null values
- shorten the names of properties.
- apply an explicit order to the properties for consistency.