### PR TITLE
added fix for Path objects in parameters not being logged and added e…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,20 @@
             <version>2.4</version>
         </dependency>
 
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/onsdigital/logging/layouts/AbstractDPLayout.java
+++ b/src/main/java/com/github/onsdigital/logging/layouts/AbstractDPLayout.java
@@ -72,4 +72,18 @@ public abstract class AbstractDPLayout extends LayoutBase<ILoggingEvent> {
     protected String toPrettyJson(JsonLogItem item) throws IOException {
         return addColour(item.getLevel(), PRETTY_OBJECT_WRITER.writeValueAsString(item)) + CoreConstants.LINE_SEPARATOR;
     }
+
+    /**
+     * Runs printStackTrace on an exception thrown in the doLayout method and re throws as a {@link RuntimeException}
+     * to obey the {@link LayoutBase} interface.
+     *
+     * @param message a context message to indicate where the exception came from.
+     * @param e       the cause.
+     * @return a run time exception.
+     */
+    protected RuntimeException doLayoutException(String message, Throwable e) {
+        RuntimeException runEx = new RuntimeException(message, e);
+        runEx.printStackTrace();
+        return runEx;
+    }
 }

--- a/src/main/java/com/github/onsdigital/logging/layouts/JsonLayout.java
+++ b/src/main/java/com/github/onsdigital/logging/layouts/JsonLayout.java
@@ -10,12 +10,14 @@ import java.io.IOException;
  */
 public class JsonLayout extends AbstractDPLayout {
 
+    static final String DO_LAYOUT_ERR = "JsonLayout.doLayout returned an unexpected error";
+
     @Override
     public String doLayout(ILoggingEvent event) {
         try {
             return toJson(new JsonLogItem(event));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw doLayoutException(DO_LAYOUT_ERR, e);
         }
     }
 }

--- a/src/main/java/com/github/onsdigital/logging/layouts/PrettyJsonLayout.java
+++ b/src/main/java/com/github/onsdigital/logging/layouts/PrettyJsonLayout.java
@@ -10,12 +10,14 @@ import java.io.IOException;
  */
 public class PrettyJsonLayout extends JsonLayout {
 
+    static final String DO_LAYOUT_ERR = "PrettyJsonLayout.doLayout returned an unexpected error";
+
     @Override
     public String doLayout(ILoggingEvent event) {
         try {
             return toPrettyJson(new JsonLogItem(event));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw doLayoutException(DO_LAYOUT_ERR, e);
         }
     }
 }

--- a/src/test/java/com/github/onsdigital/logging/LogBuilder.java
+++ b/src/test/java/com/github/onsdigital/logging/LogBuilder.java
@@ -1,0 +1,37 @@
+package com.github.onsdigital.logging;
+
+import ch.qos.logback.classic.Level;
+import com.github.onsdigital.logging.builder.LogMessageBuilder;
+
+import java.util.Map;
+
+/**
+ * Basic implementation for unit testing.
+ */
+class LogBuilder extends LogMessageBuilder {
+
+    public LogBuilder(String eventDescription) {
+        super(eventDescription);
+    }
+
+    public LogBuilder(String description, Level logLevel) {
+        super(description, logLevel);
+    }
+
+    public LogBuilder(Throwable t, Level level, String description) {
+        super(t, level, description);
+    }
+
+    public LogBuilder(Throwable t, String description) {
+        super(t, description);
+    }
+
+    @Override
+    public String getLoggerName() {
+        return null;
+    }
+
+    public Map<String, Object> getParams() {
+        return this.parameters.getParameters();
+    }
+}

--- a/src/test/java/com/github/onsdigital/logging/LogMessageBuilderTest.java
+++ b/src/test/java/com/github/onsdigital/logging/LogMessageBuilderTest.java
@@ -1,0 +1,59 @@
+package com.github.onsdigital.logging;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class LogMessageBuilderTest {
+
+    @Test
+    public void shouldNotAddParamIfKeyNull() {
+        LogBuilder lb = new LogBuilder("test");
+        lb.addParameter(null, "Some value");
+
+        assertTrue(lb.getParams().isEmpty());
+    }
+
+    @Test
+    public void shouldNotAddParamIfKeyEmpty() {
+        LogBuilder lb = new LogBuilder("test");
+        lb.addParameter("", "Some value");
+
+        assertTrue(lb.getParams().isEmpty());
+    }
+
+    @Test
+    public void shouldNotAddParamIfNull() {
+        LogBuilder lb = new LogBuilder("test");
+        lb.addParameter("key", null);
+        Map<String, Object> params = lb.getParams();
+
+        assertFalse(params.containsKey("key"));
+        assertTrue(params.isEmpty());
+    }
+
+    @Test
+    public void shouldAddPathAsString() {
+        LogBuilder lb = new LogBuilder("test");
+        Path p = Paths.get("/test/path/1");
+
+        lb.addParameter("key", p);
+        Map<String, Object> params = lb.getParams();
+
+        assertTrue(params.containsKey("key"));
+        Object target = params.get("key");
+
+        if (!(target instanceof String)) {
+            fail("expected parameter value to be type string");
+        }
+        assertThat((String) target, equalTo(p.toString()));
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="DP_LOGGER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.github.onsdigital.logging.layouts.ConfigurableLayout"/>
+        </encoder>
+    </appender>
+
+    <logger name="com.test" level="debug" additivity="false">
+        <appender-ref ref="DP_LOGGER"/>
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="DP_LOGGER"/>
+    </root>
+</configuration>


### PR DESCRIPTION
**Fix for defect**: Adding `java.nio.file.Path` objects to the logger parameters causes `org.codehaus.jackson.map.JsonMappingException cyclic  reference exception` when the JSON layout attempts to marshal the parameters to JSON. 

- Added defensive check to `addParameter` which adds `Path` objects to the parameters map as a string to prevent this.
- Exceptions thrown in the layout handlers were being swallowed - improved error handling and added update to ensure any errors are logged out.
- Added unit tests for new functionality.
- General tidy up.