### PR TITLE
Updated baseEvent.exception to include full stack trace and added mor…

### DIFF
--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -31,7 +31,6 @@ public abstract class BaseEvent<T extends BaseEvent> {
     private String namespace;
     private HTTP http;
     private Auth auth;
-    private Error error;
     private Errors errors;
 
     protected String event;
@@ -118,30 +117,19 @@ public abstract class BaseEvent<T extends BaseEvent> {
 
     public T exception(Throwable t) {
         if (null != t) {
-            this.error = new Error(t);
-        }
-        return (T) this;
-    }
-
-    public T exceptionAll(Throwable t) {
-        if (null != t) {
             this.errors = new Errors(t);
         }
         return (T) this;
     }
 
     public <T extends Throwable> T logException(T t, String event) {
-        if (t != null) {
-            this.error = new Error(t);
-        }
+        exception(t);
         log(event);
         return t;
     }
 
     public <T extends Throwable> void logAndThrow(T t, String event) throws T {
-        if (t != null) {
-            this.error = new Error(t);
-        }
+        exception(t);
         log(event);
         throw t;
     }
@@ -210,8 +198,8 @@ public abstract class BaseEvent<T extends BaseEvent> {
         return this.auth;
     }
 
-    public Error getError() {
-        return this.error;
+    public Errors getErrors() {
+        return this.errors;
     }
 
     @Override
@@ -226,7 +214,6 @@ public abstract class BaseEvent<T extends BaseEvent> {
                 .append("severity", severity)
                 .append("http", http)
                 .append("auth", auth)
-                .append("error", error)
                 .append("errors", errors)
                 .toString();
     }

--- a/src/main/java/com/github/onsdigital/logging/v2/event/Error.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/Error.java
@@ -1,6 +1,8 @@
 package com.github.onsdigital.logging.v2.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Map;
 
@@ -31,5 +33,29 @@ public class Error {
 
     public Map<String, Object> getData() {
         return this.data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Error error = (Error) o;
+
+        return new EqualsBuilder()
+                .append(getMessage(), error.getMessage())
+                .append(getStackTraces(), error.getStackTraces())
+                .append(getData(), error.getData())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getMessage())
+                .append(getStackTraces())
+                .append(getData())
+                .toHashCode();
     }
 }

--- a/src/main/java/com/github/onsdigital/logging/v2/event/Errors.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/Errors.java
@@ -1,5 +1,8 @@
 package com.github.onsdigital.logging.v2.event;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,5 +29,29 @@ public class Errors {
 
     private void addError(Throwable t) {
         errors.add(new Error(t));
+    }
+
+    public List<Error> getErrors() {
+        return this.errors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Errors errors1 = (Errors) o;
+
+        return new EqualsBuilder()
+                .append(getErrors(), errors1.getErrors())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getErrors())
+                .toHashCode();
     }
 }

--- a/src/test/java/com/github/onsdigital/logging/v2/event/ErrorsTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/event/ErrorsTest.java
@@ -1,0 +1,30 @@
+package com.github.onsdigital.logging.v2.event;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ErrorsTest {
+
+    @Test
+    public void testErrorsAsExpected() {
+        Throwable inner = new RuntimeException("inner");
+        Throwable outter = new RuntimeException("outter", inner);
+
+        Errors err = new Errors(outter);
+
+        assertThat(err.getErrors().size(), equalTo(2));
+
+        Error actual = err.getErrors().get(0);
+        assertError(err.getErrors().get(0), new Error(outter));
+        assertError(err.getErrors().get(1), new Error(inner));
+    }
+
+    private void assertError(Error actual, Error expected) {
+        assertThat(actual, equalTo(expected));
+        assertThat(actual.getMessage(), equalTo(expected.getMessage()));
+        assertThat(actual.getStackTraces(), equalTo(expected.getStackTraces()));
+        assertThat(actual.getData(), equalTo(expected.getData()));
+    }
+}

--- a/src/test/java/com/github/onsdigital/logging/v2/event/ThirdPartyEventTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/event/ThirdPartyEventTest.java
@@ -31,20 +31,25 @@ public class ThirdPartyEventTest {
 
     @Test
     public void shouldAddExceptionIfExists() {
-        Throwable thrownException = new RuntimeException("nargle");
+        Throwable bar = new RuntimeException("bar");
+        Throwable foo = new RuntimeException("foo", bar);
 
         when(event.getThrowableProxy())
                 .thenReturn(throwableProxy);
         when(throwableProxy.getThrowable())
-                .thenReturn(thrownException);
+                .thenReturn(foo);
 
         ThirdPartyEvent thirdPartyEvent = new ThirdPartyEvent("", Severity.ERROR, event, logStore);
-        Error actual = thirdPartyEvent.getError();
+        Errors actual = thirdPartyEvent.getErrors();
 
-        String expectedMessage = thrownException.getClass().getName() + ": " + thrownException.getMessage();
-        assertThat(actual.getMessage(), equalTo(expectedMessage));
 
-        StackTrace[] expectedStackTrace = stackTraceArrayFromThrowable(thrownException);
-        assertThat(actual.getStackTraces(), equalTo(expectedStackTrace));
+        Errors expected = new Errors(foo);
+
+        String expectedMessage = foo.getClass().getName() + ": " + foo.getMessage();
+        assertThat(actual.getErrors().size(), equalTo(2));
+        assertThat(actual.getErrors().get(0).getMessage(), equalTo(expectedMessage));
+
+        StackTrace[] expectedStackTrace = stackTraceArrayFromThrowable(foo);
+        assertThat(actual.getErrors().get(0).getStackTraces(), equalTo(expectedStackTrace));
     }
 }

--- a/src/test/java/com/github/onsdigital/logging/v2/layout/ThirdPartyEventLayoutTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/layout/ThirdPartyEventLayoutTest.java
@@ -71,7 +71,7 @@ public class ThirdPartyEventLayoutTest {
         assertNotNull("created_at incorrect", e.getCreateAt());
         assertNull("http incorrect", e.getHttp());
         assertNull("auth incorrect", e.getAuth());
-        assertNull("error incorrect", e.getError());
+        assertNull("error incorrect", e.getErrors());
         assertNull("trace_id incorrect", e.getTraceID());
         assertNull("span_id incorrect", e.getSpanID());
 
@@ -106,7 +106,7 @@ public class ThirdPartyEventLayoutTest {
         assertNotNull("created_at incorrect", e.getCreateAt());
         assertNull("http incorrect", e.getHttp());
         assertNull("auth incorrect", e.getAuth());
-        assertNull("error incorrect", e.getError());
+        assertNull("error incorrect", e.getErrors());
         assertNull("trace_id incorrect", e.getTraceID());
         assertNull("span_id incorrect", e.getSpanID());
 


### PR DESCRIPTION
⚠️ 
This is a breaking change. I don't think any(many) of our apps will be affected but if they are I will fix them as part of upgrading to the latest release.
⚠️  

Updated base event/logger to output full exception stack trace.
- `exception(Throwable t)` now adds all nested throwable to the log output to increase visibility of errors for debugging.
- Removed `BaseEvent.getError()` and replaced with `BaseEvent.getErrors()`.
- Updated and and unit tests
