### PR TITLE
http no longer stored in MDC for thread duration and fixed trace ID d…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
             <version>2.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
@@ -72,7 +78,6 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.8.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -60,7 +60,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
     }
 
     /**
-     * Depreecated use {@link BaseEvent#request(HttpServletRequest)} instead.
+     * Deprecated use {@link BaseEvent#request(HttpServletRequest)} instead.
      */
     @Deprecated
     public T beginHTTP(HttpServletRequest req) {
@@ -70,7 +70,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
     }
 
     /**
-     * Depreecated use {@link BaseEvent#request(HttpServletRequest)} instead.
+     * Deprecated use {@link BaseEvent#request(HttpServletRequest)} instead.
      */
     @Deprecated
     public T beginHTTP(HTTP httpDetails) {
@@ -80,7 +80,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
     }
 
     /**
-     * Depreecated use {@link BaseEvent#response(HttpServletResponse)} instead.
+     * Deprecated use {@link BaseEvent#response(HttpServletResponse)} instead.
      */
     @Deprecated
     public T endHTTP(HttpServletResponse resp) {
@@ -90,7 +90,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
     }
 
     /**
-     * Depreecated use {@link BaseEvent#response(HttpServletResponse)} instead.
+     * Deprecated use {@link BaseEvent#response(HttpServletResponse)} instead.
      */
     @Deprecated
     public T endHTTP(int statusCode) {

--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -59,33 +59,56 @@ public abstract class BaseEvent<T extends BaseEvent> {
         return (T) this;
     }
 
+    /**
+     * Depreecated use {@link BaseEvent#request(HttpServletRequest)} instead.
+     */
+    @Deprecated
     public T beginHTTP(HttpServletRequest req) {
         store.saveTraceID(req);
-        getHTPPSafe().begin(req);
-        store.saveHTTP(http);
+        getHTPPSafe().request(req);
         return (T) this;
     }
 
+    /**
+     * Depreecated use {@link BaseEvent#request(HttpServletRequest)} instead.
+     */
+    @Deprecated
     public T beginHTTP(HTTP httpDetails) {
         traceID(store.getTraceID());
-        this.http = new HTTP().begin(httpDetails);
-        store.saveHTTP(http);
+        this.http = new HTTP().request(httpDetails);
         return (T) this;
     }
 
+    /**
+     * Depreecated use {@link BaseEvent#response(HttpServletResponse)} instead.
+     */
+    @Deprecated
     public T endHTTP(HttpServletResponse resp) {
-        this.http = store.getHTTP();
-        if (this.http != null) {
-            this.http.end(resp);
-        }
+        this.http = getHTPPSafe();
+        this.http.response(resp);
         return (T) this;
     }
 
+    /**
+     * Depreecated use {@link BaseEvent#response(HttpServletResponse)} instead.
+     */
+    @Deprecated
     public T endHTTP(int statusCode) {
-        this.http = store.getHTTP();
-        if (this.http != null) {
-            this.http.end(statusCode);
-        }
+        this.http = getHTPPSafe();
+        this.http.response(statusCode);
+        return (T) this;
+    }
+
+    public T request(HttpServletRequest req) {
+        store.saveTraceID(req);
+        getHTPPSafe().request(req);
+        return (T) this;
+    }
+
+    public T response(HttpServletResponse resp) {
+        this.http = getHTPPSafe();
+        this.traceID = store.getTraceID();
+        this.http.response(resp);
         return (T) this;
     }
 
@@ -137,9 +160,6 @@ public abstract class BaseEvent<T extends BaseEvent> {
     public void log(String event) {
         this.event = event;
         this.traceID = store.getTraceID();
-        if (http == null) {
-            this.http = store.getHTTP();
-        }
 
         if (auth == null) {
             this.auth = store.getAuth();

--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -7,6 +7,8 @@ import com.github.onsdigital.logging.v2.DPLogger;
 import com.github.onsdigital.logging.v2.storage.LogStore;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -105,7 +107,20 @@ public abstract class BaseEvent<T extends BaseEvent> {
         return (T) this;
     }
 
+    public T request(HttpUriRequest req) {
+        store.saveTraceID(req);
+        getHTPPSafe().request(req);
+        return (T) this;
+    }
+
     public T response(HttpServletResponse resp) {
+        this.http = getHTPPSafe();
+        this.traceID = store.getTraceID();
+        this.http.response(resp);
+        return (T) this;
+    }
+
+    public T response(HttpResponse resp) {
         this.http = getHTPPSafe();
         this.traceID = store.getTraceID();
         this.http.response(resp);

--- a/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
@@ -4,19 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.time.Duration;
-import java.time.ZonedDateTime;
 
 public class HTTP {
 
     @JsonProperty("status_code")
     private Integer statusCode;
-
-    @JsonProperty("started_at")
-    private ZonedDateTime startedAt;
-
-    @JsonProperty("ended_at")
-    private ZonedDateTime endedAt;
 
     private String method;
     private String path;
@@ -26,13 +18,7 @@ public class HTTP {
     private Integer port;
     private Long duration;
 
-    /**
-     * For a new http request being received by the app. Adds http request details to the log event.
-     *
-     * @param req the request to get the values from.
-     * @return
-     */
-    public HTTP begin(HttpServletRequest req) {
+    public HTTP request(HttpServletRequest req) {
         if (req != null) {
             this.method = req.getMethod();
             this.path = req.getRequestURI();
@@ -40,21 +26,31 @@ public class HTTP {
             this.scheme = req.getScheme();
             this.host = req.getServerName();
             this.port = req.getServerPort();
-            this.startedAt = ZonedDateTime.now();
         }
         return this;
     }
 
-    public HTTP begin(HTTP that) {
-        if (that != null) {
-            this.method = that.method;
-            this.path = that.path;
-            this.query = that.query;
-            this.scheme = that.scheme;
-            this.host = that.host;
-            this.port = that.port;
-            this.startedAt = ZonedDateTime.now();
+    public HTTP request(HTTP details) {
+        if (details != null) {
+            this.method = details.method;
+            this.path = details.path;
+            this.query = details.query;
+            this.scheme = details.scheme;
+            this.host = details.host;
+            this.port = details.port;
         }
+        return this;
+    }
+
+    public HTTP response(HttpServletResponse resp) {
+        if (resp != null) {
+            this.statusCode = resp.getStatus();
+        }
+        return this;
+    }
+
+    public HTTP response(int status) {
+        this.statusCode = statusCode;
         return this;
     }
 
@@ -90,37 +86,6 @@ public class HTTP {
 
     public HTTP setPort(Integer port) {
         this.port = port;
-        return this;
-    }
-
-    /**
-     * Capture http response details and add them to the HTTP event
-     */
-    public HTTP end(HttpServletResponse resp) {
-        if (resp != null) {
-            this.statusCode = resp.getStatus();
-            this.endedAt = ZonedDateTime.now();
-        }
-        calcDuration();
-        return this;
-    }
-
-    public HTTP end(int statusCode) {
-        this.statusCode = statusCode;
-        this.endedAt = ZonedDateTime.now();
-        calcDuration();
-        return this;
-    }
-
-    public HTTP calcDuration() {
-        if (this.startedAt == null) {
-            startedAt = ZonedDateTime.now();
-        }
-
-        if (endedAt == null) {
-            this.endedAt = ZonedDateTime.now();
-        }
-        this.duration = Duration.between(startedAt, endedAt).toNanos();
         return this;
     }
 }

--- a/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
@@ -1,6 +1,8 @@
 package com.github.onsdigital.logging.v2.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -42,9 +44,28 @@ public class HTTP {
         return this;
     }
 
+    public HTTP request(HttpUriRequest req) {
+        if (req != null) {
+            this.method = req.getMethod();
+            this.path = req.getURI().getPath();
+            this.query = req.getURI().getQuery();
+            this.scheme = req.getURI().getScheme();
+            this.host = req.getURI().getHost();
+            this.port = req.getURI().getPort();
+        }
+        return this;
+    }
+
     public HTTP response(HttpServletResponse resp) {
         if (resp != null) {
             this.statusCode = resp.getStatus();
+        }
+        return this;
+    }
+
+    public HTTP response(HttpResponse resp) {
+        if (resp != null) {
+            this.statusCode = resp.getStatusLine().getStatusCode();
         }
         return this;
     }

--- a/src/main/java/com/github/onsdigital/logging/v2/event/ThirdPartyEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/ThirdPartyEvent.java
@@ -5,19 +5,25 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import com.github.onsdigital.logging.v2.storage.LogStore;
 
+import static com.github.onsdigital.logging.v2.DPLogger.logConfig;
+import static java.text.MessageFormat.format;
+
 public class ThirdPartyEvent extends BaseEvent {
 
+    static final String EVENT_DESCRIPTION = "external library event";
+    static final String NAMESPACE_FMT = "{0} {1}";
     private String raw;
 
     public ThirdPartyEvent(String namespace, Severity severity, String raw, LogStore logStore) {
-        super(namespace, severity, logStore);
-        super.event = "third party log";
+        super(logConfig().getNamespace(), severity, logStore);
+        super.event = formatEvent(namespace);
+        this.traceID(logStore.getTraceID());
         this.raw = raw;
     }
 
     public ThirdPartyEvent(String namespace, Severity severity, ILoggingEvent e, LogStore logStore) {
-        super(namespace, severity, logStore);
-        super.event = "third party log";
+        super(logConfig().getNamespace(), severity, logStore);
+        super.event = formatEvent(namespace);
         this.raw = e.getFormattedMessage();
         this.traceID(logStore.getTraceID());
 
@@ -25,11 +31,13 @@ public class ThirdPartyEvent extends BaseEvent {
             IThrowableProxy iThrowableProxy = e.getThrowableProxy();
             if (iThrowableProxy instanceof ThrowableProxy) {
                 Throwable t = ((ThrowableProxy) iThrowableProxy).getThrowable();
-                // TODO - once the centralised logging schema is updated this needs to use the recurive method to
-                // capture the full error.
                 this.exception(t);
             }
         }
+    }
+
+    static String formatEvent(String eventNamespace) {
+        return format(NAMESPACE_FMT, EVENT_DESCRIPTION, eventNamespace);
     }
 
     public String getRaw() {

--- a/src/main/java/com/github/onsdigital/logging/v2/nop/NopStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/nop/NopStore.java
@@ -1,16 +1,11 @@
 package com.github.onsdigital.logging.v2.nop;
 
 import com.github.onsdigital.logging.v2.event.Auth;
-import com.github.onsdigital.logging.v2.event.HTTP;
 import com.github.onsdigital.logging.v2.storage.LogStore;
 
 import javax.servlet.http.HttpServletRequest;
 
 public class NopStore implements LogStore {
-    @Override
-    public void saveHTTP(HTTP http) {
-
-    }
 
     @Override
     public void saveTraceID(HttpServletRequest req) {
@@ -25,11 +20,6 @@ public class NopStore implements LogStore {
     @Override
     public void saveAuth(Auth auth) {
 
-    }
-
-    @Override
-    public HTTP getHTTP() {
-        return null;
     }
 
     @Override

--- a/src/main/java/com/github/onsdigital/logging/v2/nop/NopStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/nop/NopStore.java
@@ -2,6 +2,7 @@ package com.github.onsdigital.logging.v2.nop;
 
 import com.github.onsdigital.logging.v2.event.Auth;
 import com.github.onsdigital.logging.v2.storage.LogStore;
+import org.apache.http.client.methods.HttpUriRequest;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -9,6 +10,11 @@ public class NopStore implements LogStore {
 
     @Override
     public void saveTraceID(HttpServletRequest req) {
+
+    }
+
+    @Override
+    public void saveTraceID(HttpUriRequest httpUriRequest) {
 
     }
 

--- a/src/main/java/com/github/onsdigital/logging/v2/storage/LogStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/storage/LogStore.java
@@ -1,12 +1,15 @@
 package com.github.onsdigital.logging.v2.storage;
 
 import com.github.onsdigital.logging.v2.event.Auth;
+import org.apache.http.client.methods.HttpUriRequest;
 
 import javax.servlet.http.HttpServletRequest;
 
 public interface LogStore {
 
     void saveTraceID(HttpServletRequest req);
+
+    void saveTraceID(HttpUriRequest httpUriRequest);
 
     void saveTraceID(String id);
 

--- a/src/main/java/com/github/onsdigital/logging/v2/storage/LogStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/storage/LogStore.java
@@ -1,21 +1,16 @@
 package com.github.onsdigital.logging.v2.storage;
 
 import com.github.onsdigital.logging.v2.event.Auth;
-import com.github.onsdigital.logging.v2.event.HTTP;
 
 import javax.servlet.http.HttpServletRequest;
 
 public interface LogStore {
-
-    void saveHTTP(HTTP http);
 
     void saveTraceID(HttpServletRequest req);
 
     void saveTraceID(String id);
 
     void saveAuth(Auth auth);
-
-    HTTP getHTTP();
 
     String getTraceID();
 

--- a/src/main/java/com/github/onsdigital/logging/v2/storage/MDCLogStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/storage/MDCLogStore.java
@@ -4,6 +4,8 @@ import com.github.onsdigital.logging.v2.LoggingException;
 import com.github.onsdigital.logging.v2.event.Auth;
 import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.slf4j.MDC;
 
 import javax.servlet.http.HttpServletRequest;
@@ -32,6 +34,13 @@ public class MDCLogStore implements LogStore {
         String traceID = getTraceIDForRequest(req);
         traceID = defaultIfBlank(traceID, newTraceID());
         MDC.put(TRACE_ID_KEY, traceID);
+    }
+
+    @Override
+    public void saveTraceID(HttpUriRequest httpUriRequest) {
+        Header header = httpUriRequest.getFirstHeader(TRACE_ID_KEY);
+        String headerValue = header != null ? header.getValue() : "";
+        saveTraceID(headerValue);
     }
 
     @Override

--- a/src/main/java/com/github/onsdigital/logging/v2/storage/MDCLogStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/storage/MDCLogStore.java
@@ -2,7 +2,6 @@ package com.github.onsdigital.logging.v2.storage;
 
 import com.github.onsdigital.logging.v2.LoggingException;
 import com.github.onsdigital.logging.v2.event.Auth;
-import com.github.onsdigital.logging.v2.event.HTTP;
 import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
@@ -11,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.UUID;
 
 import static java.text.MessageFormat.format;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 public class MDCLogStore implements LogStore {
 
@@ -28,29 +28,16 @@ public class MDCLogStore implements LogStore {
     }
 
     @Override
-    public void saveHTTP(HTTP http) {
-        try {
-            MDC.put(HTTP_KEY, serialiser.marshallHTTP(http));
-        } catch (LoggingException ex) {
-            LoggingException wrapped = new LoggingException(format(MARSHALL_ERR_FMT, HTTP_KEY, getTraceID()), ex);
-            System.err.println(wrapped);
-        }
-    }
-
-    @Override
     public void saveTraceID(HttpServletRequest req) {
-        String traceID = req.getHeader(TRACE_ID_KEY);
-        if (StringUtils.isEmpty(traceID)) {
-            traceID = UUID.randomUUID().toString();
-        }
+        String traceID = getTraceIDForRequest(req);
+        traceID = defaultIfBlank(traceID, newTraceID());
         MDC.put(TRACE_ID_KEY, traceID);
     }
 
     @Override
     public void saveTraceID(String id) {
-        if (StringUtils.isEmpty(id)) {
-            id = UUID.randomUUID().toString();
-        }
+        id = defaultIfBlank(getTraceID(), id);
+        id = defaultIfBlank(id, newTraceID());
         MDC.put(TRACE_ID_KEY, id);
     }
 
@@ -61,21 +48,6 @@ public class MDCLogStore implements LogStore {
         } catch (LoggingException ex) {
             LoggingException wrapper = new LoggingException(format(MARSHALL_ERR_FMT, AUTH_KEY, getTraceID()), ex);
             System.err.println(wrapper);
-        }
-    }
-
-    @Override
-    public HTTP getHTTP() {
-        String httpJson = MDC.get(HTTP_KEY);
-        if (StringUtils.isEmpty(httpJson)) {
-            return null;
-        }
-        try {
-            return serialiser.unmarshallHTTP(httpJson);
-        } catch (LoggingException ex) {
-            LoggingException wrapped = new LoggingException(format(UNMARSHALL_ERR_FMT, HTTP_KEY, getTraceID()), ex);
-            System.err.println(wrapped);
-            return null;
         }
     }
 
@@ -97,5 +69,13 @@ public class MDCLogStore implements LogStore {
             System.err.println(wrapped);
             return null;
         }
+    }
+
+    private String getTraceIDForRequest(HttpServletRequest req) {
+        return defaultIfBlank(getTraceID(), req.getHeader(TRACE_ID_KEY));
+    }
+
+    private String newTraceID() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/src/test/java/com/github/onsdigital/logging/v2/ExampleAPI.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/ExampleAPI.java
@@ -1,0 +1,59 @@
+package com.github.onsdigital.logging.v2;
+
+import com.github.onsdigital.logging.v2.config.Builder;
+import com.github.onsdigital.logging.v2.serializer.JacksonLogSerialiser;
+import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
+import com.github.onsdigital.logging.v2.storage.LogStore;
+import com.github.onsdigital.logging.v2.storage.MDCLogStore;
+
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
+import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
+import static spark.Spark.after;
+import static spark.Spark.before;
+import static spark.Spark.get;
+import static spark.Spark.port;
+
+public class ExampleAPI {
+
+    static {
+        System.setProperty("logback.configurationFile", ExampleAPI.class.getResource("/logback.xml").getPath());
+    }
+
+    public static void main(String[] args) throws Exception {
+        setUpLogging();
+        port(8088);
+
+        before("/*", (req, resp) -> {
+            info().request(req.raw()).log("request receieved");
+        });
+
+        after("/*", ((request, response) -> {
+            info().request(request.raw()).response(response.raw()).log("request processing compelete");
+        }));
+
+        get("/hello", (req, resp) -> {
+            info().log("handling hello request");
+            return "hello world";
+        });
+
+
+        get("/break", (req, resp) -> {
+            throw new RuntimeException("three", new RuntimeException("two", new RuntimeException("one")));
+        });
+
+
+    }
+
+    static void setUpLogging() throws Exception {
+        LogSerialiser serialiser = new JacksonLogSerialiser(true);
+        LogStore store = new MDCLogStore(serialiser);
+        Logger logger = new LoggerImpl("logging-example");
+
+        DPLogger.init(new Builder()
+                .logger(logger)
+                .logStore(store)
+                .serialiser(serialiser)
+                .dataNamespace("data")
+                .create());
+    }
+}

--- a/src/test/java/com/github/onsdigital/logging/v2/ExampleAPI.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/ExampleAPI.java
@@ -6,7 +6,6 @@ import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
 import com.github.onsdigital.logging.v2.storage.LogStore;
 import com.github.onsdigital.logging.v2.storage.MDCLogStore;
 
-import static com.github.onsdigital.logging.v2.event.SimpleEvent.error;
 import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 import static spark.Spark.after;
 import static spark.Spark.before;
@@ -35,12 +34,6 @@ public class ExampleAPI {
             info().log("handling hello request");
             return "hello world";
         });
-
-
-        get("/break", (req, resp) -> {
-            throw new RuntimeException("three", new RuntimeException("two", new RuntimeException("one")));
-        });
-
 
     }
 

--- a/src/test/java/com/github/onsdigital/logging/v2/storage/MDCLogStoreTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/storage/MDCLogStoreTest.java
@@ -2,7 +2,6 @@ package com.github.onsdigital.logging.v2.storage;
 
 import com.github.onsdigital.logging.v2.LoggingException;
 import com.github.onsdigital.logging.v2.event.Auth;
-import com.github.onsdigital.logging.v2.event.HTTP;
 import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
@@ -16,9 +15,9 @@ import org.slf4j.MDC;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.PrintStream;
+import java.util.UUID;
 
 import static com.github.onsdigital.logging.v2.storage.MDCLogStore.AUTH_KEY;
-import static com.github.onsdigital.logging.v2.storage.MDCLogStore.HTTP_KEY;
 import static com.github.onsdigital.logging.v2.storage.MDCLogStore.MARSHALL_ERR_FMT;
 import static com.github.onsdigital.logging.v2.storage.MDCLogStore.TRACE_ID_KEY;
 import static com.github.onsdigital.logging.v2.storage.MDCLogStore.UNMARSHALL_ERR_FMT;
@@ -33,7 +32,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -78,93 +76,6 @@ public class MDCLogStoreTest {
     @After
     public void tearDown() {
         MDC.clear();
-    }
-
-    @Test
-    public void testSaveHTTPSuccess() throws Exception {
-        HTTP http = new HTTP();
-
-        when(serialiser.marshallHTTP(http))
-                .thenReturn(httpJson);
-
-        store.saveHTTP(http);
-
-        verify(serialiser, times(1)).marshallHTTP(http);
-        assertThat(MDC.get(HTTP_KEY), equalTo(httpJson));
-    }
-
-    @Test
-    public void testSaveHTTPMarshallError() throws Exception {
-        HTTP http = new HTTP();
-        PrintStream stdErr = mock(PrintStream.class);
-        System.setErr(stdErr);
-
-        when(request.getHeader("trace_id")).thenReturn(TRACE_ID);
-        store.saveTraceID(request);
-
-        when(serialiser.marshallHTTP(http))
-                .thenThrow(new LoggingException("bork"));
-
-        store.saveHTTP(http);
-
-        ArgumentCaptor<LoggingException> captor = ArgumentCaptor.forClass(LoggingException.class);
-
-        verify(serialiser, times(1)).marshallHTTP(http);
-        verify(stdErr, times(1)).println(captor.capture());
-
-        LoggingException actual = captor.getValue();
-        assertThat(actual.getMessage(), equalTo(format(MARSHALL_ERR_FMT, HTTP_KEY, TRACE_ID)));
-    }
-
-    @Test
-    public void testGetHTTPSuccess() throws Exception {
-        MDC.put(HTTP_KEY, httpJson);
-
-        HTTP http = new HTTP();
-
-        when(serialiser.unmarshallHTTP(httpJson))
-                .thenReturn(http);
-
-        HTTP result = store.getHTTP();
-
-        verify(serialiser, times(1)).unmarshallHTTP(httpJson);
-        assertThat(result, equalTo(http));
-    }
-
-    @Test
-    public void testGetHTTPSerialiserException() throws Exception {
-        MDC.put(HTTP_KEY, httpJson);
-        MDC.put(TRACE_ID_KEY, TRACE_ID);
-
-        PrintStream stdErr = mock(PrintStream.class);
-        System.setErr(stdErr);
-
-        LoggingException exception = new LoggingException("bork");
-
-        when(serialiser.unmarshallHTTP(httpJson))
-                .thenThrow(exception);
-
-        ArgumentCaptor<LoggingException> captor = ArgumentCaptor.forClass(LoggingException.class);
-
-        HTTP result = store.getHTTP();
-
-        verify(serialiser, times(1)).unmarshallHTTP(httpJson);
-        verify(stdErr, times(1)).println(captor.capture());
-
-        assertThat(result, is(nullValue()));
-        assertThat(captor.getValue().getMessage(), equalTo(format(UNMARSHALL_ERR_FMT, HTTP_KEY, TRACE_ID)));
-    }
-
-    @Test
-    public void testGetHTTPNoValueSavedS() throws Exception {
-        PrintStream stdErr = mock(PrintStream.class);
-        System.setErr(stdErr);
-
-        HTTP result = store.getHTTP();
-
-        assertThat(result, is(nullValue()));
-
-        verifyZeroInteractions(serialiser, stdErr);
     }
 
     @Test
@@ -262,5 +173,81 @@ public class MDCLogStoreTest {
         verify(stdErr, times(1)).println(captor.capture());
         verify(serialiser, times(1)).unmarshallAuth(authJson);
         assertThat(captor.getValue().getMessage(), equalTo(format(UNMARSHALL_ERR_FMT, AUTH_KEY, TRACE_ID)));
+    }
+
+    @Test
+    public void saveTraceId_valueAlreadyStored_requestValueShouldNotOverrideExistingValue() {
+        String existingValue = "0987654321";
+        MDC.put(TRACE_ID_KEY, existingValue);
+
+        String requestTraceId = "1234567890";
+        when(request.getParameter(TRACE_ID_KEY))
+                .thenReturn(requestTraceId);
+
+        store.saveTraceID(request);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo(existingValue));
+    }
+
+    @Test
+    public void saveTraceId_noIDInRequestOrStore_shouldGenerateAndStoreNewID() {
+        when(request.getParameter(TRACE_ID_KEY))
+                .thenReturn("");
+
+        store.saveTraceID(request);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertTrue(StringUtils.isNotEmpty(actualValue));
+
+        UUID.fromString(actualValue);
+    }
+
+    @Test
+    public void saveTraceId_RequestIDHeaderNoValueStored_shouldStoreRequestHeader() {
+        String value = "1234567890";
+        when(request.getHeader(TRACE_ID_KEY))
+                .thenReturn(value);
+
+        store.saveTraceID(request);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo(value));
+    }
+
+    @Test
+    public void saveTraceId_emptyValueNoStoredValue_shouldGenerateAndStoreValue() {
+        store.saveTraceID(request);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertTrue(StringUtils.isNotEmpty(actualValue));
+    }
+
+    @Test
+    public void saveTraceId_paramEmptyAndValueStored_shouldUseStoredValue() {
+        MDC.put(TRACE_ID_KEY, TRACE_ID);
+
+        store.saveTraceID("");
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo(TRACE_ID));
+    }
+
+    @Test
+    public void saveTraceId_paramNotEmptyAndValueStored_shouldUseStoredValue() {
+        MDC.put(TRACE_ID_KEY, TRACE_ID);
+
+        store.saveTraceID("1234567890");
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo(TRACE_ID));
+    }
+
+    @Test
+    public void saveTraceId_paramNotEmptyAndStoreEmpty_shouldUseParamValue() {
+        store.saveTraceID("1234567890");
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo("1234567890"));
     }
 }

--- a/src/test/java/com/github/onsdigital/logging/v2/storage/MDCLogStoreTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/storage/MDCLogStoreTest.java
@@ -4,6 +4,8 @@ import com.github.onsdigital.logging.v2.LoggingException;
 import com.github.onsdigital.logging.v2.event.Auth;
 import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -249,5 +251,49 @@ public class MDCLogStoreTest {
 
         String actualValue = MDC.get(TRACE_ID_KEY);
         assertThat(actualValue, equalTo("1234567890"));
+    }
+
+    @Test
+    public void saveTraceID_headerNullStoreNull_shouldGenerateNewID() {
+        HttpUriRequest req = mock(HttpUriRequest.class);
+        when(req.getFirstHeader(TRACE_ID_KEY))
+                .thenReturn(null);
+
+        store.saveTraceID(req);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertTrue(StringUtils.isNotEmpty(actualValue));
+    }
+
+    @Test
+    public void saveTraceID_headerNullStoreValueExists_shouldUseStoredValue() {
+        HttpUriRequest req = mock(HttpUriRequest.class);
+        when(req.getFirstHeader(TRACE_ID_KEY))
+                .thenReturn(null);
+
+        MDC.put(TRACE_ID_KEY, TRACE_ID);
+
+        store.saveTraceID(req);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo(TRACE_ID));
+    }
+
+    @Test
+    public void saveTraceID_headerAndStoreValuesExists_shouldUseStoredValue() {
+        Header header = mock(Header.class);
+        when(header.getValue())
+                .thenReturn("1234567890");
+
+        HttpUriRequest req = mock(HttpUriRequest.class);
+        when(req.getFirstHeader(TRACE_ID_KEY))
+                .thenReturn(header);
+
+        MDC.put(TRACE_ID_KEY, TRACE_ID);
+
+        store.saveTraceID(req);
+
+        String actualValue = MDC.get(TRACE_ID_KEY);
+        assertThat(actualValue, equalTo(TRACE_ID));
     }
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,16 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
+    <property scope="context" name="default.logger.name" value="dp-logger-default"/>
+    <property scope="context" name="default.logger.formatted" value="false"/>
+
     <appender name="DP_LOGGER" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="com.github.onsdigital.logging.layouts.ConfigurableLayout"/>
+        <encoder>
+            <pattern>%msg%n</pattern>
         </encoder>
     </appender>
 
-    <logger name="com.test" level="debug" additivity="false">
+    <appender name="THIRD_PARTY" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.github.onsdigital.logging.v2.layout.ThirdPartyEventLayout">
+                <Pattern>%n%msg</Pattern>
+            </layout>
+        </encoder>
+    </appender>
+
+    <logger name="logging-example" level="info" additivity="false">
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <root level="info">
-        <appender-ref ref="DP_LOGGER"/>
+    <root level="error">
+        <appender-ref ref="THIRD_PARTY"/>
     </root>
+
 </configuration>


### PR DESCRIPTION
### Fix logging library defects

- Updated the logger to no longer store HTTP details in a Thread Map for the duration of the request. This was a nice idea but was buggy and led to cases where the wrong HTTP details were being logged for a request. The logger still provides functionality for capturing HTTP request details but these are no longer persisted.
- Fixed bug where a new trace ID being generated despite an existing ID was stored in threadlocal.
- Added tests for the fix above.
- Added Example Spark API using the logging library.
- Added additional HTTP request/response method for different HTTP request implementations & added tests.
- Updated 3rd party log event to use app namespace, original event namespace appended to event field.