### PR TITLE
fixed failing tests and fixed NPE for http.request() if req.uri is null

### DIFF
--- a/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
@@ -6,6 +6,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URI;
 
 public class HTTP {
 
@@ -47,13 +48,19 @@ public class HTTP {
     public HTTP request(HttpUriRequest req) {
         if (req != null) {
             this.method = req.getMethod();
-            this.path = req.getURI().getPath();
-            this.query = req.getURI().getQuery();
-            this.scheme = req.getURI().getScheme();
-            this.host = req.getURI().getHost();
-            this.port = req.getURI().getPort();
+            extractUriDetails(req.getURI());
         }
         return this;
+    }
+
+    private void extractUriDetails(URI uri) {
+        if (uri != null) {
+            this.path = uri.getPath();
+            this.query = uri.getQuery();
+            this.scheme = uri.getScheme();
+            this.host = uri.getHost();
+            this.port = uri.getPort();
+        }
     }
 
     public HTTP response(HttpServletResponse resp) {
@@ -70,7 +77,7 @@ public class HTTP {
         return this;
     }
 
-    public HTTP response(int status) {
+    public HTTP response(int statusCode) {
         this.statusCode = statusCode;
         return this;
     }

--- a/src/test/java/com/github/onsdigital/logging/v2/layout/ThirdPartyEventLayoutTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/layout/ThirdPartyEventLayoutTest.java
@@ -63,9 +63,9 @@ public class ThirdPartyEventLayoutTest {
         layout.doLayout(mockEvent);
 
         ThirdPartyEvent e = argumentCaptor.getValue();
-        assertThat("event incorrect", e.getEvent(), equalTo("third party log"));
+        assertThat("event incorrect", e.getEvent(), equalTo("external library event test.logger.name"));
         assertThat("event incorrect", e.getRaw(), equalTo("hello world"));
-        assertThat("namespace incorrect", e.getNamespace(), equalTo("test.logger.name"));
+        assertThat("namespace incorrect", e.getNamespace(), equalTo("dp-logger-default"));
         assertThat("severity incorrect", e.getSeverity(), equalTo(Severity.INFO.getLevel()));
         assertThat("data incorrect", e.getData().isEmpty(), is(true));
         assertNotNull("created_at incorrect", e.getCreateAt());
@@ -98,9 +98,9 @@ public class ThirdPartyEventLayoutTest {
         assertThat(result, equalTo("error while attempting to marshallHTTP log event to json: bork"));
 
         ThirdPartyEvent e = eventCaptor.getValue();
-        assertThat("event incorrect", e.getEvent(), equalTo("third party log"));
+        assertThat("event incorrect", e.getEvent(), equalTo("external library event test.logger.name"));
         assertThat("event incorrect", e.getRaw(), equalTo("hello world"));
-        assertThat("namespace incorrect", e.getNamespace(), equalTo("test.logger.name"));
+        assertThat("namespace incorrect", e.getNamespace(), equalTo("dp-logger-default"));
         assertThat("severity incorrect", e.getSeverity(), equalTo(Severity.INFO.getLevel()));
         assertThat("data incorrect", e.getData().isEmpty(), is(true));
         assertNotNull("created_at incorrect", e.getCreateAt());


### PR DESCRIPTION
- Fixed failing tests
- Added defensive check in `HTTP.request()` to prevent null pointer ex if `request.uri` is null.