### PR TITLE
fix log store to use X-Request-Id header when looking for a trace ID …

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -22,7 +22,7 @@
         <appender-ref ref="DP_LOGGER"/>
     </logger>
 
-    <root level="error">
+    <root level="info">
         <appender-ref ref="THIRD_PARTY"/>
     </root>
 


### PR DESCRIPTION
- Fix defect with log store where it was looking for a `trace_id` header instead of `X-Request-Id`.
  - Updated impl to use correct header key.
  - Updated unit tests and added a couple more.
- Fixed logic to *always overrwrite* an existing traceID to ensure that we do no reuse an id set by a previous thread.
  - Updated unit tests.