### PR TITLE
Replaced http with https in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following to you `pom.xml`
             </snapshots>
             <id>central</id>
             <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
replaced http with https in the README instructions, which is required when we try to use the Central Repository