### PR TITLE
Upgrade dependencies to latest minor versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.6.2</version>
+            <version>2.12.1</version>
         </dependency>
 
         <dependency>
@@ -38,13 +38,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.4</version>
+            <version>3.11</version>
         </dependency>
 
         <dependency>
@@ -56,20 +50,20 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.4</version>
+            <version>2.8.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.13</version>
         </dependency>
 
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,7 +75,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- Upgrade dependencies to latest minor versions. This change is driven by audit failures in `the-train` service, that depends on this library.
- remove `org.apache.httpcomponents.httpcore` dependency, as it's included with `org.apache.httpcomponents.httpclient`