### PR TITLE
Added Kafka to BaseEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
             <version>4.5.13</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.10.2</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.github.onsdigital.logging.v2.DPLogger;
 import com.github.onsdigital.logging.v2.storage.LogStore;
+import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.http.HttpResponse;
@@ -32,6 +33,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
     private SafeMap data;
     private String namespace;
     private HTTP http;
+    private Kafka Kafka;
     private Auth auth;
     private Errors errors;
 
@@ -114,6 +116,19 @@ public abstract class BaseEvent<T extends BaseEvent> {
     public T endHTTP(HttpUriRequest req, HttpResponse resp) {
         this.http = new HTTP(req, resp);
         this.traceID = store.getTraceID();
+        return (T) this;
+    }
+
+    /**
+     * Capture the kafka message details for a kafka consumer or producer. A new traceID will be generated.
+     *
+     * @param msg the {@link SpecificRecordBase} to extract the kafka message details from.
+     * @param topic the Kafka topic String.
+     * @return this instance of the event with the updated kafka message details.
+     */
+    public T beginKafka(SpecificRecordBase msg, String topic) {
+        this.Kafka = new Kafka(msg, topic);
+        this.traceID = store.saveTraceID((String) null);
         return (T) this;
     }
 

--- a/src/main/java/com/github/onsdigital/logging/v2/event/Kafka.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/Kafka.java
@@ -1,0 +1,36 @@
+package com.github.onsdigital.logging.v2.event;
+
+import org.apache.avro.specific.SpecificRecordBase;
+
+/**
+ * POJO containing Kafka details required by log events.
+ */
+public class Kafka {
+
+    private SpecificRecordBase msg;
+    private String topic;
+
+    /**
+     * Construct a new Kafka instance and populate the SpecificRecordBase fields.
+     */
+    public Kafka(SpecificRecordBase msg) {
+        this(msg, "");
+    }
+
+    /**
+     * Construct a new Kafka instance and populate the SpecificRecordBase and topic fields.
+     */
+    public Kafka(SpecificRecordBase msg, String topic) {
+        this.msg = msg;
+        this.topic = topic;
+    }
+
+
+    public String getTopic() {
+        return this.topic;
+    }
+
+    public String getMessage() {
+        return this.msg.toString();
+    }
+}


### PR DESCRIPTION
- Added `beginKafka` to BaseEvent, so that users of this library can call this function to provide the message and topic. A new traceID is generated.
- Added corresponding Kafka Object (POJO) to keep the message and topic
- Added `org.apache.avro` dependency in pom file