### PR TITLE
Fix json logging format for nested exception

### DIFF
--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @JsonPropertyOrder({"created_at", "namespace", "severity", "event", "trace_id", "span_id"})
 public abstract class BaseEvent<T extends BaseEvent> {
@@ -33,7 +34,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
     private String namespace;
     private HTTP http;
     private Auth auth;
-    private Errors errors;
+    private List<Error> errors;
 
     protected String event;
     protected transient LogStore store;
@@ -143,7 +144,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
 
     public T exception(Throwable t) {
         if (null != t) {
-            this.errors = new Errors(t);
+            this.errors = new Errors(t).getErrors();
         }
         return (T) this;
     }
@@ -222,7 +223,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
         return this.auth;
     }
 
-    public Errors getErrors() {
+    public List<Error> getErrors() {
         return this.errors;
     }
 

--- a/src/test/java/com/github/onsdigital/logging/v2/event/ThirdPartyEventTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/event/ThirdPartyEventTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.List;
+
 import static com.github.onsdigital.logging.v2.event.StackTrace.stackTraceArrayFromThrowable;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -33,23 +35,20 @@ public class ThirdPartyEventTest {
     public void shouldAddExceptionIfExists() {
         Throwable bar = new RuntimeException("bar");
         Throwable foo = new RuntimeException("foo", bar);
-
         when(event.getThrowableProxy())
                 .thenReturn(throwableProxy);
         when(throwableProxy.getThrowable())
                 .thenReturn(foo);
 
         ThirdPartyEvent thirdPartyEvent = new ThirdPartyEvent("", Severity.ERROR, event, logStore);
-        Errors actual = thirdPartyEvent.getErrors();
-
+        List<Error> actual = thirdPartyEvent.getErrors();
 
         Errors expected = new Errors(foo);
-
         String expectedMessage = foo.getClass().getName() + ": " + foo.getMessage();
-        assertThat(actual.getErrors().size(), equalTo(2));
-        assertThat(actual.getErrors().get(0).getMessage(), equalTo(expectedMessage));
+        assertThat(actual.size(), equalTo(2));
+        assertThat(actual.get(0).getMessage(), equalTo(expectedMessage));
 
         StackTrace[] expectedStackTrace = stackTraceArrayFromThrowable(foo);
-        assertThat(actual.getErrors().get(0).getStackTraces(), equalTo(expectedStackTrace));
+        assertThat(actual.get(0).getStackTraces(), equalTo(expectedStackTrace));
     }
 }


### PR DESCRIPTION
What
Fix a logging format bug (https://trello.com/c/pCndmbxh/813-java-logging-is-incorrectly-outputting-json-format-of-logs-s1)

How to review

- Is it a v3 change as this appears to be a breaking change for backward compatibility, specially BaseEvent.getErrors used to return an Errors instance and now returning a List<Error> 
- Creating the class just to get access to its properties

Who
anyone not me