### PR TITLE
Upgrade jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <fasterxml.jackson.version>2.14.1</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/com/github/onsdigital/logging/v2/layout/ThirdPartyEventLayoutTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/layout/ThirdPartyEventLayoutTest.java
@@ -2,9 +2,7 @@ package com.github.onsdigital.logging.v2.layout;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.github.onsdigital.logging.v2.DPLogger;
 import com.github.onsdigital.logging.v2.LoggingException;
-import com.github.onsdigital.logging.v2.config.Config;
 import com.github.onsdigital.logging.v2.event.Severity;
 import com.github.onsdigital.logging.v2.event.ThirdPartyEvent;
 import com.github.onsdigital.logging.v2.serializer.LogSerialiser;
@@ -21,7 +19,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Upgrade jackson version to latest which removes vulnerability `sonatype-2022-6438`

Fix unit test randomly failing (dependent on execution order)