### PR TITLE
Adding OpenTelemetry traceid into logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,12 @@
             <artifactId>opentelemetry-sdk</artifactId>
             <version>1.31.0</version>
         </dependency>
-        
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api-trace</artifactId>
+            <version>0.13.1</version>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,13 @@
     </properties>
 
     <dependencies>
-
+            
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.31.0</version>
+        </dependency>
+        
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/src/main/java/com/github/onsdigital/logging/util/RequestLogUtil.java
+++ b/src/main/java/com/github/onsdigital/logging/util/RequestLogUtil.java
@@ -8,6 +8,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.util.UUID;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.TraceId;
+
 /**
  * Utility class providing common functionality for extracting details required for logging from in coming requests and
  * setting request logging headers for outbound request.
@@ -24,7 +27,9 @@ public class RequestLogUtil {
 
     public static void extractDiagnosticContext(HttpServletRequest request) {
 
-        String requestID = request.getHeader(REQUEST_ID_KEY);
+        String otelTraceID = TraceId.fromBytes(Span.current().getSpanContext().getTraceIdBytes());
+        String requestID = TraceId.isValid(otelTraceID) ? otelTraceID : request.getHeader(REQUEST_ID_KEY);
+
         if (requestID == null) {
             requestID = UUID.randomUUID().toString();
         }

--- a/src/main/java/com/github/onsdigital/logging/v2/storage/MDCLogStore.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/storage/MDCLogStore.java
@@ -42,7 +42,7 @@ public class MDCLogStore implements LogStore {
     @Override
     public String saveTraceID(HttpServletRequest req) {
         String id = req == null ? "" : req.getHeader(REQUEST_ID_HEADER);
-        return saveTraceID(id);
+        return saveTraceID(overrideRequestIDwithOtelTraceID(id));
     }
 
     @Override
@@ -52,12 +52,12 @@ public class MDCLogStore implements LogStore {
             Header header = httpUriRequest.getFirstHeader(REQUEST_ID_HEADER);
             id = getHeaderValue(header);
         }
-        return saveTraceID(id);
+        return saveTraceID(overrideRequestIDwithOtelTraceID(id));
     }
 
     @Override
     public String saveTraceID(String id) {
-        id =  overrideRequestIDwithOtelTraceID(defaultIfBlank(id, newTraceID()));
+        id =  defaultIfBlank(id, newTraceID());
         MDC.put(TRACE_ID_KEY, id);
         return id;
     }


### PR DESCRIPTION
This PR will override any existing request IDs that are being output as `trace_id` where there is an otel trace_id and it is in a valid form. This is a 16 byte array where at least one byte is non-zero.

Existing tests pass OK. The otel libraries rely heavily on static methods to fetch the current context which makes it impossible to mock them with mockito. Currently working on alternative ways of positive testing.