### PR TITLE
removed dependency for api-trace as sdk covers it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
-            <version>1.30.0</version>
+            <version>1.31.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,10 @@
     </properties>
 
     <dependencies>
-            
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
-            <version>1.31.0</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api-trace</artifactId>
-            <version>0.13.1</version>
+            <version>1.30.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This was causing issues in babbage. Examples suggested that opentelemetry-api-trace was necessary to import the tracing classes, but this seems to be outdated. In current versions the SDK is all that's needed