### PR TITLE
Update dependencies to latest minor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,14 +13,14 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <fasterxml.jackson.version>2.15.0</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.16.0</fasterxml.jackson.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
-            <version>1.31.0</version>
+            <version>1.32.0</version>
         </dependency>
 
         <dependency>
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.13</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
 
         <!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>audit-dependencies-critical</id>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -85,7 +85,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>default-jar</id>


### PR DESCRIPTION
### **What**
Update all dependencies to their latest minor version with the exception of _ch.qos.logback:logback-classic_. This dependency supports JDK 8 only on logback version 1.3.x ([logback version strategy](https://logback.qos.ch/dependencies.html)), so it's been updated to the latest minor version of 1.3.x which is [1.3.13](https://mvnrepository.com/artifact/ch.qos.logback/logback-classic)

Plugins updated to latest minor version compatible with maven 3.9.5

### **How to review**
Checkout branch locally. Ensure you are on JDK 8 version and run the tests, more info on how to run the tests can be found [here](https://confluence.ons.gov.uk/pages/viewpage.action?pageId=184748856).

### **Who can review**
A member of ONS

