### PR TITLE
Add org.slf4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.10</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
             <version>1.32.0</version>


### PR DESCRIPTION
### What
Add missing org.slf4j:slf4j-api dependency in dp-logging library to avoid updating every java project that's using dp-logging to include this dependency.

### How to review
Checkout branch locally. Ensure you are on JDK 8 version and run the tests, more info on how to run the tests can be found [here](https://confluence.ons.gov.uk/pages/viewpage.action?pageId=184748856).

### Who can review
A member of ONS