### PR TITLE
Fix/remove syntax errors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What
+
+Describe what you have changed and why.
+
+### How to review
+
+Describe the steps required to test the changes.
+
+### Who can review
+
+Describe who worked on the changes, so that other people can review.

--- a/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/BaseEvent.java
@@ -12,7 +12,6 @@ import org.apache.hc.core5.http.HttpResponse;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -99,7 +98,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
      * @param req the {@link HttpUriRequest} to extract the request details from.
      * @return this instance of the event with the updated request details.
      */
-    public T beginHTTP(HttpUriRequest req) throws URISyntaxException {
+    public T beginHTTP(HttpUriRequest req)  {
         this.traceID = store.saveTraceID(req);
         this.http = new HTTP(req);
         return (T) this;
@@ -113,7 +112,7 @@ public abstract class BaseEvent<T extends BaseEvent> {
      * @param resp the {@link HttpServletResponse} to extract the response details from.
      * @return this instance of the event with the updated request/response details.
      */
-    public T endHTTP(HttpUriRequest req, HttpResponse resp) throws URISyntaxException {
+    public T endHTTP(HttpUriRequest req, HttpResponse resp) {
         this.http = new HTTP(req, resp);
         this.traceID = store.getTraceID();
         return (T) this;

--- a/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
+++ b/src/main/java/com/github/onsdigital/logging/v2/event/HTTP.java
@@ -66,7 +66,7 @@ public class HTTP {
      *
      * @param req a {@link HttpUriRequest} to extract the request fields from.
      */
-    public HTTP(HttpUriRequest req) throws URISyntaxException {
+    public HTTP(HttpUriRequest req) {
         this(req, null);
     }
 
@@ -77,17 +77,25 @@ public class HTTP {
      * @param req  the {@link HttpUriRequest} to extract the request fields from.
      * @param resp the {@link HttpResponse} to extract the response fields from.
      */
-    public HTTP(HttpUriRequest req, HttpResponse resp) throws URISyntaxException {
+    public HTTP(HttpUriRequest req, HttpResponse resp) {
         if (req != null) {
            this.method = req.getMethod();
 
-            URI uri = req.getUri();
-            if (uri != null) {
-                this.path = defaultIfBlank(uri.getPath(), "");
-                this.query = defaultIfBlank(uri.getQuery(), "");
-                this.scheme = defaultIfBlank(uri.getScheme(), "");
-                this.host = defaultIfBlank(uri.getHost(), "");
-                this.port = uri.getPort();
+            try {
+                URI uri = req.getUri();
+                if (uri != null) {
+                    this.path = defaultIfBlank(uri.getPath(), "");
+                    this.query = defaultIfBlank(uri.getQuery(), "");
+                    this.scheme = defaultIfBlank(uri.getScheme(), "");
+                    this.host = defaultIfBlank(uri.getHost(), "");
+                    this.port = uri.getPort();
+                }
+            } catch (URISyntaxException e) {
+                // This exception is being caught here to stop consuming
+                // applications having to catch every beginHTTP log message.
+                // If the uri syntax is malformed, it will have a blank HTTP,
+                // much like if uri ends up being null above.
+                // This decision has been made for backwards-compatibility reasons.
             }
         }
 

--- a/src/test/java/com/github/onsdigital/logging/v2/event/HTTPTest.java
+++ b/src/test/java/com/github/onsdigital/logging/v2/event/HTTPTest.java
@@ -110,7 +110,7 @@ public class HTTPTest {
     }
 
     @Test
-    public void newHTTP_nullHttpUriRequest_fieldsShouldBeNull() throws URISyntaxException {
+    public void newHTTP_nullHttpUriRequest_fieldsShouldBeNull() {
         HttpUriRequest req = null;
 
         HTTP actual = new HTTP(req);


### PR DESCRIPTION
### What

Removed URISyntaxException from HTTP creation to facilitate backwards compatibility with consuming applications.

I've been upgrading Babbage to use the latest version and this has highlighted issues with introducing this change, so I'm reverting it, not causing a breaking change. 

### How to review

Check looks ok, comments make sense, tests pass. 

### Who can review

Not me. 